### PR TITLE
Upload transcipts option in profile page.

### DIFF
--- a/lib/profile.dart
+++ b/lib/profile.dart
@@ -1,5 +1,10 @@
+import 'dart:io';
+import 'package:path/path.dart' as Path; 
 import 'package:flutter/material.dart';
 import 'package:Tuter/backend/auth.dart';
+import 'package:firebase_storage/firebase_storage.dart';  
+import 'package:image_picker/image_picker.dart';   
+
 
 
 class ProfilePage extends StatefulWidget {
@@ -12,23 +17,90 @@ class ProfilePage extends StatefulWidget {
 class _ProfilePage extends State<ProfilePage> {
 
   final Auth _auth = Auth();
+  File _image = null;
+  String _uploadedFileURL;
 
-  @override
+  Future chooseFile() async{
+    await ImagePicker.pickImage(source: ImageSource.gallery).then((image){
+        setState(() {
+          _image = image;
+        });
+    });
+  }
 
+  Future uploadImage() async{
+    StorageReference storageReference = FirebaseStorage.instance.ref().child('Transcripts/${Path.basename(_image.path)}');
+    StorageUploadTask uploadTask = storageReference.putFile(_image);
+    await uploadTask.onComplete;
+
+    print('File Uploaded');
+
+    storageReference.getDownloadURL().then((imageURL){
+      setState(() {
+        _uploadedFileURL = imageURL;
+      });
+    });
+  }
+
+  void selected(String selection){
+
+      print('congrats no selecting');
+      if (selection == 'Upload Transcripts')
+        chooseFile();
+      
+      if (selection == 'Confirm Upload')
+      {
+        uploadImage();
+        setState(() {
+          _image = null;
+        });
+      }
+
+  }
+
+  @override  
   Widget build(BuildContext context) {
+    //initState();
     return Scaffold(
       appBar: AppBar(
         title: Text('Profile'),
         actions: <Widget>[
+
           FlatButton.icon(
             icon: Icon(Icons.person),
             label: Text('Log Out'),
             onPressed: () async {
               await _auth.logOut();
             },
-          )
+          ),
+
+          PopupMenuButton<String>(
+            onSelected: selected,
+            itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[
+              const PopupMenuItem<String>(
+                value: 'Upload Transcripts',
+                child: Text("Upload Transcripts"),
+              ),
+              const PopupMenuItem<String>(
+                child: Text("Edit Profile"),
+              ),
+              const PopupMenuItem<String>(
+                child: Text("Make a Report"),
+              ),
+              _image == null ? null : PopupMenuDivider(height: 15),
+              
+              _image == null ? null : 
+                const PopupMenuItem<String>(
+                  value: 'Confirm Upload',
+                  child: Text('Confirm Upload'),
+              
+              )
+            ]
+          ),
         ],
       ),
-    );
+      );
   }
 }
+
+

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -134,11 +134,25 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.1+2"
+  firebase_storage:
+    dependency: "direct main"
+    description:
+      name: firebase_storage
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.1.5"
   flutter:
     dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.6"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -170,6 +184,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.4"
+  image_picker:
+    dependency: "direct main"
+    description:
+      name: image_picker
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.5"
   js:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,9 +19,13 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  firebase_auth: ^0.15.5+3
-  provider: ^4.0.4
   cloud_firestore: ^0.13.4+2
+  firebase_auth: ^0.15.5+3
+  firebase_storage: ^3.1.5
+  provider: ^4.0.4
+  image_picker: ^0.6.5
+  
+
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
I've added the ability to add upload transcripts from the users phone gallery to our database storage. The first time it will ask you for permission to use your phone gallery before you can select an image. 

Things to do before you try: (Jeff you can skip this)
Since this adds the ability to select pictures from the phones gallery, you first need to have pictures on the phones gallery! Most of us are using emulators with no photos stored in them, so you'll need some photos to pick from. 
I made a google photos account for tuter that you can sign into on your emulator. It has 3 pictures in them. Feel free to add more options to choose from if you'd like. Sign in using the email and password I pinned in the large project chat on discord. 

Features:
- In profile page there is now a button on the top right corner that opens up a pop up menu. 
- This will open up three options, one of those being upload transcripts. 
- When you click upload transcripts it will take you to your phones gallery where you will pick a picture. 
Once you've picked a picture, click once again on the pop up menu and there will now be an extra button!
- Confirm upload will upload the picture you selected to our database storage. 

Things to do:
- Add a relationship between file uploaded and tutor account.
- Add notification on profile icon in navbar when tutor has not uploaded transcript.
- Add notification on pop up menu button for the same thing.

Feedback:
I know that clicking on the pop up menu twice to upload image is not very intuitive. We can just make an alert that asks to confirm the upload. I just also thought having a button appear from the options was neat. 